### PR TITLE
update go, reformat code,  add basic build, test, lint CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+---
+name: ci
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        go: ["1.23"]
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+          cache: true
+      - name: build
+        run: "go build ./..."
+
+  test:
+    strategy:
+      matrix:
+        go: ["1.23"]
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+          cache: true
+      - name: test
+        run: go test -race ./...
+
+  golangci:
+    strategy:
+      matrix:
+        go: ["1.23"]
+        lint: ["v1.61"]
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: ${{ matrix.lint }}

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -210,7 +210,7 @@ func (b *Bridge) add(containerId string, quiet bool) {
 
 	// Extract configured host port mappings, relevant when using --net=host
 	for port := range container.Config.ExposedPorts {
-		published := []dockerapi.PortBinding{{"0.0.0.0", port.Port()}}
+		published := []dockerapi.PortBinding{{HostIP: "0.0.0.0", HostPort: port.Port()}}
 		ports[string(port)] = servicePort(container, port, published)
 	}
 
@@ -226,7 +226,7 @@ func (b *Bridge) add(containerId string, quiet bool) {
 
 	servicePorts := make(map[string]ServicePort)
 	for key, port := range ports {
-		if b.config.Internal != true && port.HostPort == "" {
+		if !b.config.Internal && port.HostPort == "" {
 			if !quiet {
 				log.Println("ignored:", container.ID[:12], "port", port.ExposedPort, "not published on host")
 			}
@@ -298,7 +298,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	}
 	var p int
 
-	if b.config.Internal == true {
+	if b.config.Internal {
 		service.IP = port.ExposedIP
 		p, _ = strconv.Atoi(port.ExposedPort)
 	} else {

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -130,7 +130,7 @@ func (b *Bridge) Sync(quiet bool) {
 			log.Println("error listing nonExitedContainers, skipping sync", err)
 			return
 		}
-		for listingId, _ := range b.services {
+		for listingId := range b.services {
 			found := false
 			for _, container := range nonExitedContainers {
 				if listingId == container.ID {
@@ -209,8 +209,8 @@ func (b *Bridge) add(containerId string, quiet bool) {
 	ports := make(map[string]ServicePort)
 
 	// Extract configured host port mappings, relevant when using --net=host
-	for port, _ := range container.Config.ExposedPorts {
-		published := []dockerapi.PortBinding{ {"0.0.0.0", port.Port()}, }
+	for port := range container.Config.ExposedPorts {
+		published := []dockerapi.PortBinding{{"0.0.0.0", port.Port()}}
 		ports[string(port)] = servicePort(container, port, published)
 	}
 
@@ -317,7 +317,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 				service.IP = containerIp
 			}
 			log.Println("using container IP " + service.IP + " from label '" +
-				b.config.UseIpFromLabel  + "'")
+				b.config.UseIpFromLabel + "'")
 		} else {
 			log.Println("Label '" + b.config.UseIpFromLabel +
 				"' not found in container configuration")
@@ -425,7 +425,7 @@ func (b *Bridge) shouldRemove(containerId string) bool {
 func (b *Bridge) markContainerAsDying(containerId string) {
 	// cleanup after CleanupDyingTtl
 	for containerId, t := range b.dyingContainers {
-		if time.Since(t) >= time.Millisecond * time.Duration(b.config.CleanupDyingTtl) {
+		if time.Since(t) >= time.Millisecond*time.Duration(b.config.CleanupDyingTtl) {
 			delete(b.dyingContainers, containerId)
 		}
 	}

--- a/bridge/types_test.go
+++ b/bridge/types_test.go
@@ -5,7 +5,6 @@ import "net/url"
 type fakeFactory struct{}
 
 func (f *fakeFactory) New(uri *url.URL) RegistryAdapter {
-
 	return &fakeAdapter{}
 }
 
@@ -14,15 +13,19 @@ type fakeAdapter struct{}
 func (f *fakeAdapter) Ping() error {
 	return nil
 }
+
 func (f *fakeAdapter) Register(service *Service) error {
 	return nil
 }
+
 func (f *fakeAdapter) Deregister(service *Service) error {
 	return nil
 }
+
 func (f *fakeAdapter) Refresh(service *Service) error {
 	return nil
 }
+
 func (f *fakeAdapter) Services() ([]*Service, error) {
 	return nil, nil
 }

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -4,13 +4,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cenkalti/backoff"
 	dockerapi "github.com/fsouza/go-dockerclient"
 )
-
-func retry(fn func() error) error {
-	return backoff.Retry(fn, backoff.NewExponentialBackOff())
-}
 
 func mapDefault(m map[string]string, key, default_ string) string {
 	v, ok := m[key]

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -94,9 +94,9 @@ func servicePort(container *dockerapi.Container, port dockerapi.Port, published 
 		hip = "0.0.0.0"
 	}
 
-	//for overlay networks
-	//detect if container use overlay network, than set HostIP into NetworkSettings.Network[string].IPAddress
-	//better to use registrator with -internal flag
+	// for overlay networks
+	// detect if container use overlay network, than set HostIP into NetworkSettings.Network[string].IPAddress
+	// better to use registrator with -internal flag
 	nm = container.HostConfig.NetworkMode
 	if nm != "bridge" && nm != "default" && nm != "host" {
 		hip = container.NetworkSettings.Networks[nm].IPAddress

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -1,7 +1,7 @@
 package etcd
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -34,9 +34,9 @@ func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
 	}
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
-	if match, _ := regexp.Match("0\\.4\\.*", body); match == true {
+	if match, _ := regexp.Match("0\\.4\\.*", body); match {
 		log.Println("etcd: using v0 client")
 		return &EtcdAdapter{client: etcd.NewClient(urls), path: uri.Path}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gliderlabs/registrator
 
-go 1.17
+go 1.23.2
 
 require (
 	github.com/cenkalti/backoff v2.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/gliderlabs/registrator
 go 1.23.2
 
 require (
-	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/coreos/go-etcd v2.0.0+incompatible
 	github.com/fsouza/go-dockerclient v1.2.0
 	github.com/gliderlabs/pkg v0.0.0-20161206023812-36f28d47ec7a

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/cenkalti/backoff v2.0.0+incompatible h1:5IIPUHhlnUZbcHQsQou5k1Tn58nJkeJL9U+ig5CHJbY=
-github.com/cenkalti/backoff v2.0.0+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=

--- a/registrator.go
+++ b/registrator.go
@@ -36,13 +36,6 @@ var (
 	cleanupDyingTtl  = flag.Int("ttl-dying-cleanup", 60000, "TTL (in millisecond) for cleaning dying containers cache")
 )
 
-func getopt(name, def string) string {
-	if env := os.Getenv(name); env != "" {
-		return env
-	}
-	return def
-}
-
 func assert(err error) {
 	if err != nil {
 		log.Fatal(err)

--- a/registrator.go
+++ b/registrator.go
@@ -19,20 +19,22 @@ var Version string
 
 var versionChecker = usage.NewChecker("registrator", Version)
 
-var hostIp = flag.String("ip", "", "IP for ports mapped to the host")
-var internal = flag.Bool("internal", false, "Use internal ports instead of published ones")
-var explicit = flag.Bool("explicit", false, "Only register containers which have SERVICE_NAME label set")
-var useIpFromLabel = flag.String("useIpFromLabel", "", "Use IP which is stored in a label assigned to the container")
-var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
-var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
-var forceTags = flag.String("tags", "", "Append tags for all registered services")
-var resyncInterval = flag.Int("resync", 0, "Frequency with which services are resynchronized")
-var deregister = flag.String("deregister", "always", "Deregister exited services \"always\" or \"on-success\"")
-var deregisterOnStop = flag.Bool("deregister-on-stop", false, "Deregister when container stopped versus once it dies")
-var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
-var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
-var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
-var cleanupDyingTtl = flag.Int("ttl-dying-cleanup", 60000, "TTL (in millisecond) for cleaning dying containers cache")
+var (
+	hostIp           = flag.String("ip", "", "IP for ports mapped to the host")
+	internal         = flag.Bool("internal", false, "Use internal ports instead of published ones")
+	explicit         = flag.Bool("explicit", false, "Only register containers which have SERVICE_NAME label set")
+	useIpFromLabel   = flag.String("useIpFromLabel", "", "Use IP which is stored in a label assigned to the container")
+	refreshInterval  = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
+	refreshTtl       = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
+	forceTags        = flag.String("tags", "", "Append tags for all registered services")
+	resyncInterval   = flag.Int("resync", 0, "Frequency with which services are resynchronized")
+	deregister       = flag.String("deregister", "always", "Deregister exited services \"always\" or \"on-success\"")
+	deregisterOnStop = flag.Bool("deregister-on-stop", false, "Deregister when container stopped versus once it dies")
+	retryAttempts    = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
+	retryInterval    = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
+	cleanup          = flag.Bool("cleanup", false, "Remove dangling services")
+	cleanupDyingTtl  = flag.Int("ttl-dying-cleanup", 60000, "TTL (in millisecond) for cleaning dying containers cache")
+)
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {

--- a/zookeeper/zookeeper.go
+++ b/zookeeper/zookeeper.go
@@ -52,7 +52,7 @@ func (r *ZkAdapter) Register(service *bridge.Service) error {
 	publicPortString := strconv.Itoa(service.Port)
 	acl := zk.WorldACL(zk.PermAll)
 	basePath := r.path + "/" + service.Name
-	if (r.path == "/") {
+	if r.path == "/" {
 		basePath = r.path + service.Name
 	}
 	exists, _, err := r.client.Exists(basePath)
@@ -62,7 +62,7 @@ func (r *ZkAdapter) Register(service *bridge.Service) error {
 		if !exists {
 			_, err := r.client.Create(basePath, []byte{}, 0, acl)
 			if err != nil {
-				log.Println("zookeeper: failed to create base service node at path '" + basePath + "': ", err)
+				log.Println("zookeeper: failed to create base service node at path '"+basePath+"': ", err)
 			}
 		} // create base path for the service name if it missing
 		zbody := &ZnodeBody{Name: service.Name, IP: service.IP, PublicPort: service.Port, PrivatePort: privatePort, Tags: service.Tags, Attrs: service.Attrs, ContainerID: service.Origin.ContainerHostname}
@@ -73,7 +73,7 @@ func (r *ZkAdapter) Register(service *bridge.Service) error {
 			path := basePath + "/" + service.IP + ":" + publicPortString
 			_, err = r.client.Create(path, body, 1, acl)
 			if err != nil {
-				log.Println("zookeeper: failed to register service at path '" + path + "': ", err)
+				log.Println("zookeeper: failed to register service at path '"+path+"': ", err)
 			} // create service path error check
 		} // json znode body creation check
 	} // service path exists error check
@@ -91,10 +91,10 @@ func (r *ZkAdapter) Ping() error {
 
 func (r *ZkAdapter) Deregister(service *bridge.Service) error {
 	basePath := r.path + "/" + service.Name
-	if (r.path == "/") {
+	if r.path == "/" {
 		basePath = r.path + service.Name
 	}
-	publicPortString := strconv.Itoa(service.Port)	
+	publicPortString := strconv.Itoa(service.Port)
 	servicePortPath := basePath + "/" + service.IP + ":" + publicPortString
 	// Delete the service-port znode
 	err := r.client.Delete(servicePortPath, -1) // -1 means latest version number

--- a/zookeeper/zookeeper.go
+++ b/zookeeper/zookeeper.go
@@ -27,7 +27,7 @@ func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
 		log.Println("zookeeper: error checking if base path exists:", err)
 	}
 	if !exists {
-		c.Create(uri.Path, []byte{}, 0, zk.WorldACL(zk.PermAll))
+		c.Create(uri.Path, []byte{}, 0, zk.WorldACL(zk.PermAll)) // nolint:errcheck
 	}
 	return &ZkAdapter{client: c, path: uri.Path}
 }


### PR DESCRIPTION
```
fix golangci-lint warnings

Fix the following issues:

  etcd/etcd.go:39:50: S1002: should omit comparison to bool constant, can be simplified to `match` (gosimple)
        if match, _ := regexp.Match("0\\.4\\.*", body); match == true {
  etcd/etcd.go:4:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package [io] or package [os], and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
  zookeeper/zookeeper.go:30:11: Error return value of `c.Create` is not checked (errcheck)
                c.Create(uri.Path, []byte{}, 0, zk.WorldACL(zk.PermAll))
  bridge/bridge.go:229:6: S1002: should omit comparison to bool constant, can be simplified to `!b.config.Internal` (gosimple)
                if b.config.Internal != true && port.HostPort == "" {
  bridge/bridge.go:301:5: S1002: should omit comparison to bool constant, can be simplified to `b.config.Internal` (gosimple)
        if b.config.Internal == true {
  bridge/bridge.go:213:41: composites: github.com/fsouza/go-dockerclient.PortBinding struct literal uses unkeyed fields (govet)
                published := []dockerapi.PortBinding{ {"0.0.0.0", port.Port()}, }

-------------------------------------------------------------------------------
remove unused functions

-------------------------------------------------------------------------------
reformat code with gofumpt

-------------------------------------------------------------------------------
ci: build, lint and test applicaton in github actions

-------------------------------------------------------------------------------
go: increase minimum version to 1.23.2

-------------------------------------------------------------------------------
```