### PR TITLE
fix: container not registered after restart

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	dockerapi "github.com/fsouza/go-dockerclient"
 )
@@ -20,12 +19,11 @@ var serviceIDPattern = regexp.MustCompile(`^(.+?):([a-zA-Z0-9][a-zA-Z0-9_.-]+):[
 
 type Bridge struct {
 	sync.Mutex
-	registry        RegistryAdapter
-	docker          *dockerapi.Client
-	services        map[string][]*Service
-	deadContainers  map[string]*DeadContainer
-	dyingContainers map[string]time.Time
-	config          Config
+	registry       RegistryAdapter
+	docker         *dockerapi.Client
+	services       map[string][]*Service
+	deadContainers map[string]*DeadContainer
+	config         Config
 }
 
 func New(docker *dockerapi.Client, adapterUri string, config Config) (*Bridge, error) {
@@ -40,12 +38,11 @@ func New(docker *dockerapi.Client, adapterUri string, config Config) (*Bridge, e
 
 	log.Println("Using", uri.Scheme, "adapter:", uri)
 	return &Bridge{
-		docker:          docker,
-		config:          config,
-		registry:        factory.New(uri),
-		services:        make(map[string][]*Service),
-		deadContainers:  make(map[string]*DeadContainer),
-		dyingContainers: make(map[string]time.Time),
+		docker:         docker,
+		config:         config,
+		registry:       factory.New(uri),
+		services:       make(map[string][]*Service),
+		deadContainers: make(map[string]*DeadContainer),
 	}, nil
 }
 
@@ -179,11 +176,6 @@ func (b *Bridge) Sync(quiet bool) {
 }
 
 func (b *Bridge) add(containerId string, quiet bool) {
-	if _, ok := b.dyingContainers[containerId]; ok {
-		log.Println("container, ", containerId[:12], ", is dying, ignoring")
-		return
-	}
-
 	if d := b.deadContainers[containerId]; d != nil {
 		b.services[containerId] = d.Services
 		delete(b.deadContainers, containerId)
@@ -384,7 +376,6 @@ func (b *Bridge) remove(containerId string, deregister bool) {
 		b.deadContainers[containerId] = &DeadContainer{b.config.RefreshTtl, b.services[containerId]}
 	}
 	delete(b.services, containerId)
-	b.markContainerAsDying(containerId)
 }
 
 // bit set on ExitCode if it represents an exit via a signal
@@ -416,18 +407,6 @@ func (b *Bridge) shouldRemove(containerId string) bool {
 		return true
 	}
 	return false
-}
-
-func (b *Bridge) markContainerAsDying(containerId string) {
-	// cleanup after CleanupDyingTtl
-	for containerId, t := range b.dyingContainers {
-		if time.Since(t) >= time.Millisecond*time.Duration(b.config.CleanupDyingTtl) {
-			delete(b.dyingContainers, containerId)
-		}
-	}
-
-	// mark container as "dying"
-	b.dyingContainers[containerId] = time.Now()
 }
 
 var Hostname string

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -29,7 +29,6 @@ type Config struct {
 	RefreshInterval int
 	DeregisterCheck string
 	Cleanup         bool
-	CleanupDyingTtl int
 }
 
 type Service struct {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.2
 
 require (
 	github.com/coreos/go-etcd v2.0.0+incompatible
+	github.com/docker/docker v27.3.1+incompatible
 	github.com/fsouza/go-dockerclient v1.12.0
 	github.com/gliderlabs/pkg v0.0.0-20161206023812-36f28d47ec7a
 	github.com/hashicorp/consul/api v1.29.5
@@ -19,7 +20,6 @@ require (
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/docker/docker v27.3.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect

--- a/registrator.go
+++ b/registrator.go
@@ -133,7 +133,7 @@ func main() {
 	}
 
 	// Start event listener before listing containers to avoid missing anything
-	events := make(chan *dockerapi.APIEvents)
+	events := make(chan *dockerapi.APIEvents, 128)
 	assert(docker.AddEventListener(events))
 	log.Println("Listening for Docker events ...")
 

--- a/registrator.go
+++ b/registrator.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	dockerevents "github.com/docker/docker/api/types/events"
 	dockerapi "github.com/fsouza/go-dockerclient"
 	"github.com/gliderlabs/pkg/usage"
 	"github.com/simplesurance/registrator/bridge"
@@ -174,12 +175,12 @@ func main() {
 
 	// Process Docker events
 	for msg := range events {
-		switch msg.Status {
-		case "start":
+		switch dockerevents.Action(msg.Action) {
+		case dockerevents.ActionStart, dockerevents.ActionUnPause:
 			go b.Add(msg.ID)
-		case "die":
+		case dockerevents.ActionDie:
 			go b.RemoveOnExit(msg.ID)
-		case "kill":
+		case dockerevents.ActionKill:
 			if *deregisterOnStop {
 				go b.RemoveOnExit(msg.ID)
 			}

--- a/registrator.go
+++ b/registrator.go
@@ -34,7 +34,6 @@ var (
 	retryAttempts    = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
 	retryInterval    = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
 	cleanup          = flag.Bool("cleanup", false, "Remove dangling services")
-	cleanupDyingTtl  = flag.Int("ttl-dying-cleanup", 60000, "TTL (in millisecond) for cleaning dying containers cache")
 )
 
 func assert(err error) {
@@ -110,7 +109,6 @@ func main() {
 		RefreshInterval: *refreshInterval,
 		DeregisterCheck: *deregister,
 		Cleanup:         *cleanup,
-		CleanupDyingTtl: *cleanupDyingTtl,
 	})
 
 	assert(err)


### PR DESCRIPTION
When a container is started, stopped and started it is not registered again.
It isn't because it is marked as dying and dying containers are not registered again.
The dying state is only removed after ttl-dying-cleanup expires and another container was stopped in the meantime. Only when a container is stopped the dying list is cleaned up.

Remove marking container as dying, this probably exists to prevent that a container is reregistered while it is shutting down. To prevent that this happens only consider containers that are in running or restarted state when running the periodic sync operation.